### PR TITLE
Add explanation about green check condition for transparency

### DIFF
--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -20,7 +20,7 @@ export default function About(): JSX.Element {
         mit dem Stand vom 12.01.2022.
       </p>
       <p>
-        Ein Test wird mit einem grünen Harken angezeigt, wenn er Infizierte mit sehr hoher Viruslast zu über 75% erkennt.
+        Ein Test wird mit einem grünen Haken angezeigt, wenn er Infizierte mit sehr hoher Viruslast zu über 75% erkennt.
       </p>
       <p>
         Solltest du dazu Fragen oder Anmerkungen haben oder einen Fehler entdeckt haben, melde dich

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -20,6 +20,9 @@ export default function About(): JSX.Element {
         mit dem Stand vom 12.01.2022.
       </p>
       <p>
+        Ein Test wird mit einem grünen Harken angezeigt, wenn er Infizierte mit sehr hoher Viruslast zu über 75% erkennt.
+      </p>
+      <p>
         Solltest du dazu Fragen oder Anmerkungen haben oder einen Fehler entdeckt haben, melde dich
         gerne bei uns:
       </p>

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -19,8 +19,12 @@ export default function About(): JSX.Element {
         </a>{' '}
         mit dem Stand vom 12.01.2022.
       </p>
-      <p>
-        Ein Test wird mit einem grünen Haken angezeigt, wenn er Infizierte mit sehr hoher Viruslast zu über 75% erkennt.
+            <p>
+        Ein Test wird mit einem grünen Haken angezeigt, wenn die Sensitivität bei sehr hoher
+        Viruslast (Cq ≤ 25) mehr als 75% beträgt. Dies entspricht dem vom{' '}
+        <a href="https://www.pei.de/SharedDocs/Downloads/DE/newsroom/dossiers/evaluierung-sensitivitaet-sars-cov-2-antigentests.pdf?__blob=publicationFile">
+          Paul-Ehrlich-Institut angenommenen "Stand der Technik".
+        </a>
       </p>
       <p>
         Solltest du dazu Fragen oder Anmerkungen haben oder einen Fehler entdeckt haben, melde dich


### PR DESCRIPTION
In the app there is currently no way to determine why one test gets a green and another test gets a red mark. I had to look it up in the code. For transparency reason I suggest to add the condition on the about page.