### PR TITLE
Add button to toggle between front/rear camera

### DIFF
--- a/src/components/Scanner/BarcodeScannerComponent.tsx
+++ b/src/components/Scanner/BarcodeScannerComponent.tsx
@@ -11,12 +11,14 @@ const BarcodeScannerComponent = ({
 }): ReactElement => {
   const ref = useRef(null);
   const [showModal, setShowModal] = useState(false);
+  const [frontCamera, setFrontCamera] = useState(false);
+
   const quaggaConfig = {
     inputStream: {
       constraints: {
         height: window.innerHeight * 0.8 * window.devicePixelRatio,
         width: window.innerWidth * window.devicePixelRatio,
-        facingMode: 'environment',
+        facingMode: frontCamera ? 'environment' : 'user',
         focusMode: 'continuous',
         aspectRatio: { ideal: (window.innerHeight * 0.8) / window.innerWidth },
       },
@@ -92,7 +94,7 @@ const BarcodeScannerComponent = ({
         </>
       ) : (
         <>
-          <HowToOverlay />
+          <HowToOverlay toggleFrontCamera={() => setFrontCamera(!frontCamera)} />
           <div id={'scanner'} ref={ref} />
         </>
       )}

--- a/src/components/Scanner/HowToOverlay.tsx
+++ b/src/components/Scanner/HowToOverlay.tsx
@@ -1,6 +1,30 @@
 import barcodeImage from './barcode.svg';
-import React from 'react';
-export function HowToOverlay(): JSX.Element {
+import React, { CSSProperties } from 'react';
+export function HowToOverlay({
+  toggleFrontCamera
+}: {
+  toggleFrontCamera: () => void;
+}): JSX.Element {
+  const buttonStyle: CSSProperties = {
+    textDecoration: 'none',
+    font: 'Open Sans',
+    cursor: 'pointer',
+    borderRight: '2.5px solid white',
+    borderTop: '5px solid white',
+    boxSizing: 'border-box',
+    display: 'block',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: '2px solid black',
+    padding: '.75em',
+    marginTop: '1em',
+    textAlign: 'center',
+    fontSize: '1em',
+    backgroundColor: 'black',
+    fontWeight: '700',
+    fontFamily: 'Open Sans Condensed',
+    color: 'white',
+  };
   return (
     <div
       style={{
@@ -14,7 +38,6 @@ export function HowToOverlay(): JSX.Element {
         width: '100%',
         height: '100%',
         flexDirection: 'column',
-        pointerEvents: 'none',
       }}
     >
       <img width="50%" src={barcodeImage} style={{ marginBottom: '2em', opacity: '20%' }} />
@@ -29,6 +52,7 @@ export function HowToOverlay(): JSX.Element {
       >
         Bitte scanne den Strichcode auf der Verpackung des Schnelltests
       </div>
+      <button onClick={toggleFrontCamera} style={buttonStyle}>Kamera wechseln</button>
     </div>
   );
 }


### PR DESCRIPTION
Fixes #2 by adding a button to toggle between the front and rear camera.

You probably want to replace the text with an icon, but I wasn't sure what style / license you'd prefer, so I added a simple text. I've allowed edits from maintainers on this PR, so please feel free to replace the text with an adequate icon, if you're interested.