### PR TITLE
Add notice to switch on torch

### DIFF
--- a/src/components/Scanner/HowToOverlay.tsx
+++ b/src/components/Scanner/HowToOverlay.tsx
@@ -27,7 +27,15 @@ export function HowToOverlay(): JSX.Element {
           textAlign: 'center',
         }}
       >
-        Bitte scanne den Strichcode auf der Verpackung des Schnelltests
+        <div>Bitte scanne den Strichcode auf der Verpackung des Schnelltests</div>
+        <div
+          style={{
+            fontWeight: 'normal',
+            fontSize: '0.75em',
+          }}
+        >
+          Wenn das Bild zu dunkel ist, benutze die Taschenlampe Deines Smartphones.
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
In Chrome also my Honor 6 smartphone only shows a dark screen:
As described in https://github.com/ericblade/quagga2#video-too-dark switching on the torch helps.

As long as we do not integrate capabilities as described there I would recommend to at least show a hint to the user, how to mitigate the issue.

BTW: This relates also to https://github.com/zerforschung/schnelltesttest.de/issues/34