### PR TITLE
Add button for torch / flashlight (#34)

### DIFF
--- a/src/components/Scanner/BarcodeScannerComponent.tsx
+++ b/src/components/Scanner/BarcodeScannerComponent.tsx
@@ -19,7 +19,7 @@ const BarcodeScannerComponent = ({
       constraints: {
         height: window.innerHeight * 0.8 * window.devicePixelRatio,
         width: window.innerWidth * window.devicePixelRatio,
-        facingMode: frontCamera ? 'environment' : 'user',
+        facingMode: frontCamera ? 'user' : 'environment',
         focusMode: 'continuous',
         aspectRatio: { ideal: (window.innerHeight * 0.8) / window.innerWidth },
       },

--- a/src/components/Scanner/BarcodeScannerComponent.tsx
+++ b/src/components/Scanner/BarcodeScannerComponent.tsx
@@ -11,12 +11,14 @@ const BarcodeScannerComponent = ({
 }): ReactElement => {
   const ref = useRef(null);
   const [showModal, setShowModal] = useState(false);
+  const [frontCamera, setFrontCamera] = useState(false);
+
   const quaggaConfig = {
     inputStream: {
       constraints: {
         height: window.innerHeight * 0.8 * window.devicePixelRatio,
         width: window.innerWidth * window.devicePixelRatio,
-        facingMode: 'environment',
+        facingMode: frontCamera ? 'environment' : 'user',
         focusMode: 'continuous',
         aspectRatio: { ideal: (window.innerHeight * 0.8) / window.innerWidth },
       },
@@ -92,7 +94,7 @@ const BarcodeScannerComponent = ({
         </>
       ) : (
         <>
-          <HowToOverlay />
+          <HowToOverlay toggleFrontCamera={() => setFrontCamera(!frontCamera)} />
           <div id={'scanner'} ref={ref} />
         </>
       )}

--- a/src/components/Scanner/BarcodeScannerComponent.tsx
+++ b/src/components/Scanner/BarcodeScannerComponent.tsx
@@ -12,6 +12,7 @@ const BarcodeScannerComponent = ({
   const ref = useRef(null);
   const [showModal, setShowModal] = useState(false);
   const [frontCamera, setFrontCamera] = useState(false);
+  const [torchEnabled, setTorchEnabled] = useState(false);
 
   const quaggaConfig = {
     inputStream: {
@@ -94,7 +95,19 @@ const BarcodeScannerComponent = ({
         </>
       ) : (
         <>
-          <HowToOverlay toggleFrontCamera={() => setFrontCamera(!frontCamera)} />
+          <HowToOverlay
+            toggleFrontCamera={() => setFrontCamera(!frontCamera)}
+            torchEnabled={torchEnabled}
+            toggleTorchEnabled={() => {
+              const track = Quagga.CameraAccess.getActiveTrack();
+              if (track && typeof track.getCapabilities === 'function') {
+                track.applyConstraints({
+                  advanced: [{ torch: !torchEnabled } as MediaTrackConstraintSet],
+                });
+                setTorchEnabled(!torchEnabled);
+              }
+            }}
+          />
           <div id={'scanner'} ref={ref} />
         </>
       )}

--- a/src/components/Scanner/HowToOverlay.tsx
+++ b/src/components/Scanner/HowToOverlay.tsx
@@ -1,9 +1,13 @@
 import barcodeImage from './barcode.svg';
 import React, { CSSProperties } from 'react';
 export function HowToOverlay({
-  toggleFrontCamera
+  toggleFrontCamera,
+  torchEnabled,
+  toggleTorchEnabled,
 }: {
   toggleFrontCamera: () => void;
+  torchEnabled: boolean;
+  toggleTorchEnabled: () => void;
 }): JSX.Element {
   const buttonStyle: CSSProperties = {
     textDecoration: 'none',
@@ -17,7 +21,7 @@ export function HowToOverlay({
     justifyContent: 'center',
     border: '2px solid black',
     padding: '.75em',
-    marginTop: '1em',
+    margin: '1em',
     textAlign: 'center',
     fontSize: '1em',
     backgroundColor: 'black',
@@ -52,7 +56,19 @@ export function HowToOverlay({
       >
         Bitte scanne den Strichcode auf der Verpackung des Schnelltests
       </div>
-      <button onClick={toggleFrontCamera} style={buttonStyle}>Kamera wechseln</button>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+        }}
+      >
+        <button onClick={toggleFrontCamera} style={buttonStyle}>
+          Kamera wechseln
+        </button>
+        <button onClick={toggleTorchEnabled} style={buttonStyle}>
+          Taschenlampe {!!torchEnabled.toString()}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/Scanner/HowToOverlay.tsx
+++ b/src/components/Scanner/HowToOverlay.tsx
@@ -1,6 +1,30 @@
 import barcodeImage from './barcode.svg';
-import React from 'react';
-export function HowToOverlay(): JSX.Element {
+import React, { CSSProperties } from 'react';
+export function HowToOverlay({
+  toggleFrontCamera
+}: {
+  toggleFrontCamera: () => void;
+}): JSX.Element {
+  const buttonStyle: CSSProperties = {
+    textDecoration: 'none',
+    font: 'Open Sans',
+    cursor: 'pointer',
+    borderRight: '2.5px solid white',
+    borderTop: '5px solid white',
+    boxSizing: 'border-box',
+    display: 'block',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: '2px solid black',
+    padding: '.75em',
+    marginTop: '1em',
+    textAlign: 'center',
+    fontSize: '1em',
+    backgroundColor: 'black',
+    fontWeight: '700',
+    fontFamily: 'Open Sans Condensed',
+    color: 'white',
+  };
   return (
     <div
       style={{
@@ -14,7 +38,6 @@ export function HowToOverlay(): JSX.Element {
         width: '100%',
         height: '100%',
         flexDirection: 'column',
-        pointerEvents: 'none',
       }}
     >
       <img width="50%" src={barcodeImage} style={{ marginBottom: '2em', opacity: '20%' }} />
@@ -29,6 +52,7 @@ export function HowToOverlay(): JSX.Element {
       >
         Bitte scanne den Strichcode auf der Verpackung des Schnelltests
       </div>
+      <button onClick={toggleFrontCamera} style={buttonStyle}>Kamera wechseln</button>
     </div>
   );
 }

--- a/src/components/Scanner/HowToOverlay.tsx
+++ b/src/components/Scanner/HowToOverlay.tsx
@@ -66,7 +66,7 @@ export function HowToOverlay({
           Kamera wechseln
         </button>
         <button onClick={toggleTorchEnabled} style={buttonStyle}>
-          Taschenlampe {!!torchEnabled.toString()}
+          Taschenlampe
         </button>
       </div>
     </div>


### PR DESCRIPTION
Fixes #34 
(Depends on)/includes the camera toggling feature from #54.

Torch is only supported on Chrome on Android.
Toggling between the front/rear cameras has been successfully tested on Safari (iOS), Firefox (Android) and Chrome (Android)